### PR TITLE
Fixed body html regex (fixes #30)

### DIFF
--- a/hn/hn.py
+++ b/hn/hn.py
@@ -303,12 +303,12 @@ class Story(object):
                         # html of comment, may not be valid
                         try:
                             pat = re.compile(
-                                r'<span class="comment"><font color=".*">(.*)</font></span>')
+                                r'<span class="comment"><font color="[^"]*">(.*)</font></span>')
                             body_html = re.match(pat, str(spans[1]).replace(
                                 '\n', '')).groups()[0]
                         except AttributeError:
                             pat = re.compile(
-                                r'<span class="comment"><font color=".*">(.*)</font></p><p><font size="1">')
+                                r'<span class="comment"><font color="[^"]*">(.*)</font></p><p><font size="1">')
                             body_html = re.match(pat, str(spans[1]).replace(
                                 '\n', '')).groups()[0]
 

--- a/tests/test_story_get_comments.py
+++ b/tests/test_story_get_comments.py
@@ -63,6 +63,15 @@ class TestStoryGetComments(unittest.TestCase):
         self.assertTrue(bool(comment.body))
         self.assertTrue(bool(comment.body_html))
 
+    def test_comment_body_html(self):
+        """
+        Tests for both html and plaintext content in body html
+        """
+        comment = self.comments[0].body_html
+        self.assertEqual(comment.index("Healthcare.gov"), 0)
+        self.assertGreaterEqual(comment.find(
+            '<a href="https://news.ycombinator.com/item?id=7312442"'), 0)
+
     def test_get_nested_comments(self):
         comment = self.comments[0].body
         self.assertEqual(comment.index("Healthcare.gov"), 0)


### PR DESCRIPTION
The wild card in the font color attribute matcher was getting greedy and matching too much of the html. Constrained it to within the double quotes.
